### PR TITLE
Update RBC_CPP.cpp

### DIFF
--- a/RBC_CPP.cpp
+++ b/RBC_CPP.cpp
@@ -4,178 +4,152 @@
 // Date        : July 21, 2013
 //============================================================================
 
-// AUXILIARY TIMER FUNCTIONS
-
+#include <array>
+#include <chrono>       // time measurement
+#include <cmath>        // std::abs, std::log, std::pow
+#include <cstddef>      // std::size_t
 #include <iostream>
-#include <math.h>       // power
-#include <cmath>        // abs
-using namespace std;
+#include <limits>       // std::numeric_limits
 
-// The next few lines are just for counting time
-//  Windows
-#ifdef _WIN32
-#include <Windows.h>
-double get_cpu_time(){
-    FILETIME a,b,c,d;
-    if (GetProcessTimes(GetCurrentProcess(),&a,&b,&c,&d) != 0){
-        //  Returns total user time.
-        //  Can be tweaked to include kernel times as well.
-        return
-        (double)(d.dwLowDateTime |
-                 ((unsigned long long)d.dwHighDateTime << 32)) * 0.0000001;
-    }else{
-        //  Handle error
-        return 0;
-    }
-}
-//  Posix/Linux
-#else
-#include <ctime>        // time
-double get_cpu_time(){
-    return (double)clock() / CLOCKS_PER_SEC;
-}
-#endif
+// fixed-size vector, size: Rows
+template <std::size_t Rows> using Vector = std::array<double, Rows>;
 
-int main() {
-    
-   double cpu0  = get_cpu_time();
-  
-  ///////////////////////////////////////////////////////////////////////////////////////////
-  // 1. Calibration
-  ///////////////////////////////////////////////////////////////////////////////////////////
+// fixed-size matrix, size: Rows * Columns
+template <std::size_t Rows, std::size_t Columns> using Matrix = std::array<Vector<Columns>, Rows>;
 
-  const double aalpha = 0.33333333333;     // Elasticity of output w.r.t. capital
-  const double bbeta  = 0.95;              // Discount factor;
+int main()
+{
+	const auto time_0 = std::chrono::steady_clock::now();
 
-  // Productivity values
+	///////////////////////////////////////////////////////////////////////////////////////////
+	// 1. Calibration
+	///////////////////////////////////////////////////////////////////////////////////////////
 
-  double vProductivity[5] ={0.9792, 0.9896, 1.0000, 1.0106, 1.0212};
+	const auto aalpha = 1. / 3.;          // Elasticity of output w.r.t. capital
+	const auto bbeta = 0.95;              // Discount factor;
 
-  // Transition matrix
-  double mTransition[5][5] = {
-			{0.9727, 0.0273, 0.0000, 0.0000, 0.0000},
-			{0.0041, 0.9806, 0.0153, 0.0000, 0.0000},
-			{0.0000, 0.0082, 0.9837, 0.0082, 0.0000},
-			{0.0000, 0.0000, 0.0153, 0.9806, 0.0041},
-			{0.0000, 0.0000, 0.0000, 0.0273, 0.9727}
-			};
+	// Productivity values
 
-  ///////////////////////////////////////////////////////////////////////////////////////////
-  // 2. Steady State
-  ///////////////////////////////////////////////////////////////////////////////////////////
+	const std::size_t nGridProductivity = 5;
+	const Vector<nGridProductivity> vProductivity{ { 0.9792, 0.9896, 1.0000, 1.0106, 1.0212 } };
 
-  double capitalSteadyState = pow(aalpha*bbeta,1/(1-aalpha));
-  double outputSteadyState  = pow(capitalSteadyState,aalpha);
-  double consumptionSteadyState = outputSteadyState-capitalSteadyState;
+	// Transition matrix
+	const Matrix<nGridProductivity, nGridProductivity> mTransition{ {
+		{ 0.9727, 0.0273, 0.0000, 0.0000, 0.0000 },
+		{ 0.0041, 0.9806, 0.0153, 0.0000, 0.0000 },
+		{ 0.0000, 0.0082, 0.9837, 0.0082, 0.0000 },
+		{ 0.0000, 0.0000, 0.0153, 0.9806, 0.0041 },
+		{ 0.0000, 0.0000, 0.0000, 0.0273, 0.9727 }
+	} };
 
-  cout <<"Output = "<<outputSteadyState<<", Capital = "<<capitalSteadyState<<", Consumption = "<<consumptionSteadyState<<"\n";
-  cout <<" ";
+	///////////////////////////////////////////////////////////////////////////////////////////
+	// 2. Steady State
+	///////////////////////////////////////////////////////////////////////////////////////////
 
-  // We generate the grid of capital
-  int nCapital, nCapitalNextPeriod, gridCapitalNextPeriod, nProductivity, nProductivityNextPeriod;
-  const int nGridCapital = 17820, nGridProductivity = 5;
-  double vGridCapital[nGridCapital];
+	const auto capitalSteadyState = std::pow(aalpha * bbeta, 1. / (1. - aalpha));
+	const auto outputSteadyState = std::pow(capitalSteadyState, aalpha);
+	const auto consumptionSteadyState = outputSteadyState - capitalSteadyState;
 
-  for (nCapital = 0; nCapital < nGridCapital; ++nCapital){
-    vGridCapital[nCapital] = 0.5*capitalSteadyState+0.00001*nCapital;
-  }
+	std::cout << "Output = " << outputSteadyState << ", Capital = " << capitalSteadyState << ", Consumption = " << consumptionSteadyState << "\n";
 
-  // 3. Required matrices and vectors
+	// We generate the grid of capital
+	const std::size_t nGridCapital = 17820;
+	Vector<nGridCapital> vGridCapital;
 
-  double mOutput[nGridCapital][nGridProductivity];
-  double mValueFunction[nGridCapital][nGridProductivity];
-  double mValueFunctionNew[nGridCapital][nGridProductivity];
-  double mPolicyFunction[nGridCapital][nGridProductivity];
-  double expectedValueFunction[nGridCapital][nGridProductivity];
+	for (std::size_t nCapital = 0; nCapital < nGridCapital; ++nCapital)
+		vGridCapital[nCapital] = 0.5 * capitalSteadyState + 0.00001 * nCapital;
 
-  // 4. We pre-build output for each point in the grid
+	// 3. Required matrices and vectors
 
-  for (nProductivity = 0; nProductivity<nGridProductivity; ++nProductivity){
-    for (nCapital = 0; nCapital < nGridCapital; ++nCapital){
-      mOutput[nCapital][nProductivity] = vProductivity[nProductivity]*pow(vGridCapital[nCapital],aalpha);
-    }
-  }
+	Matrix<nGridCapital, nGridProductivity> mOutput; // default-initialization (indeterminate value)
+	Matrix<nGridCapital, nGridProductivity> mValueFunction = {}; // value-initialization
+	Matrix<nGridCapital, nGridProductivity> mValueFunctionNew = {}; // value-initialization
+	Matrix<nGridCapital, nGridProductivity> mPolicyFunction = {}; // value-initialization
+	Matrix<nGridCapital, nGridProductivity> expectedValueFunction; // default-initialization (indeterminate value)
 
-  // 5. Main iteration
+	// 4. We pre-build output for each point in the grid
 
-  double maxDifference = 10.0, diff, diffHighSoFar;
-  double tolerance = 0.0000001;
-  double valueHighSoFar, valueProvisional, consumption, capitalChoice;
-
-  int iteration = 0;
-
-  while (maxDifference>tolerance){
-
-    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
-      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
-	expectedValueFunction[nCapital][nProductivity] = 0.0;
-	for (nProductivityNextPeriod = 0;nProductivityNextPeriod<nGridProductivity;++nProductivityNextPeriod){
-	  expectedValueFunction[nCapital][nProductivity] += mTransition[nProductivity][nProductivityNextPeriod]*mValueFunction[nCapital][nProductivityNextPeriod];
-	}
-      }
-    }
-
-    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
-
-      // We start from previous choice (monotonicity of policy function)
-      gridCapitalNextPeriod = 0;
-
-      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
-
-	valueHighSoFar = -100000.0;
-	capitalChoice  = vGridCapital[0];
-
-	for (nCapitalNextPeriod = gridCapitalNextPeriod;nCapitalNextPeriod<nGridCapital;++nCapitalNextPeriod){
-
-	  consumption = mOutput[nCapital][nProductivity]-vGridCapital[nCapitalNextPeriod];
-	  valueProvisional = (1-bbeta)*log(consumption)+bbeta*expectedValueFunction[nCapitalNextPeriod][nProductivity];
-
-	  if (valueProvisional>valueHighSoFar){
-	    valueHighSoFar = valueProvisional;
-	    capitalChoice = vGridCapital[nCapitalNextPeriod];
-	    gridCapitalNextPeriod = nCapitalNextPeriod;
-	  }
-	  else{
-	    break; // We break when we have achieved the max
-	  }
-
-	  mValueFunctionNew[nCapital][nProductivity] = valueHighSoFar;
-	  mPolicyFunction[nCapital][nProductivity] = capitalChoice;
+	for (std::size_t nProductivity = 0; nProductivity < nGridProductivity; ++nProductivity)
+	{
+		for (std::size_t nCapital = 0; nCapital < nGridCapital; ++nCapital)
+			mOutput[nCapital][nProductivity] = vProductivity[nProductivity] * std::pow(vGridCapital[nCapital], aalpha);
 	}
 
-      }
+	// 5. Main iteration
 
-    }
+	const double tolerance = 0.0000001;
+	auto maxDifference = 10.0;
+	std::size_t iteration = 0;
 
-    diffHighSoFar = -100000.0;
-    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
-      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
-	diff = std::abs(mValueFunction[nCapital][nProductivity]-mValueFunctionNew[nCapital][nProductivity]);
-	if (diff>diffHighSoFar){
-	  diffHighSoFar = diff;
+	while (maxDifference > tolerance)
+	{
+		for (std::size_t nProductivity = 0; nProductivity < nGridProductivity; ++nProductivity)
+		{
+			for (std::size_t nCapital = 0; nCapital < nGridCapital; ++nCapital)
+			{
+				expectedValueFunction[nCapital][nProductivity] = 0.0;
+				for (std::size_t nProductivityNextPeriod = 0; nProductivityNextPeriod < nGridProductivity; ++nProductivityNextPeriod)
+					expectedValueFunction[nCapital][nProductivity] += mTransition[nProductivity][nProductivityNextPeriod] * mValueFunction[nCapital][nProductivityNextPeriod];
+			}
+		}
+		
+		for (std::size_t nProductivity = 0; nProductivity < nGridProductivity; ++nProductivity)
+		{
+			// We start from previous choice (monotonicity of policy function)
+			std::size_t gridCapitalNextPeriod = 0;
+			for (std::size_t nCapital = 0; nCapital < nGridCapital; ++nCapital)
+			{
+				auto valueHighSoFar = -std::numeric_limits<double>::infinity();
+				auto capitalChoice = vGridCapital[0];
+				
+				for (std::size_t nCapitalNextPeriod = gridCapitalNextPeriod; nCapitalNextPeriod < nGridCapital; ++nCapitalNextPeriod)
+				{
+					const auto consumption = mOutput[nCapital][nProductivity] - vGridCapital[nCapitalNextPeriod];
+					const auto valueProvisional = (1. - bbeta) * std::log(consumption) + bbeta * expectedValueFunction[nCapitalNextPeriod][nProductivity];
+					if (valueProvisional > valueHighSoFar)
+					{
+						valueHighSoFar = valueProvisional;
+						capitalChoice = vGridCapital[nCapitalNextPeriod];
+						gridCapitalNextPeriod = nCapitalNextPeriod;
+					}
+					else
+					{
+						mValueFunctionNew[nCapital][nProductivity] = valueHighSoFar;
+						mPolicyFunction[nCapital][nProductivity] = capitalChoice;
+						// We break when we have achieved the max (note: of a monotonic function)
+						break;
+					}
+					mValueFunctionNew[nCapital][nProductivity] = valueHighSoFar;
+					mPolicyFunction[nCapital][nProductivity] = capitalChoice;
+				}
+			}
+		}
+		
+		double diffHighSoFar = -std::numeric_limits<double>::infinity();
+		for (std::size_t nProductivity = 0; nProductivity < nGridProductivity; ++nProductivity)
+		{
+			for (std::size_t nCapital = 0; nCapital<nGridCapital; ++nCapital)
+			{
+				const auto diff = std::abs(mValueFunction[nCapital][nProductivity] - mValueFunctionNew[nCapital][nProductivity]);
+				if (diff > diffHighSoFar) diffHighSoFar = diff;
+				mValueFunction[nCapital][nProductivity] = mValueFunctionNew[nCapital][nProductivity];
+			}
+		}
+		maxDifference = diffHighSoFar;
+		++iteration;
+		if ((iteration % 10 == 0) || (iteration == 1))
+			std::cout << "Iteration = " << iteration << ", Sup Diff = " << maxDifference << "\n";
 	}
-	mValueFunction[nCapital][nProductivity] = mValueFunctionNew [nCapital][nProductivity];
-      }
-    }
-    maxDifference = diffHighSoFar;
 
-    iteration = iteration+1;
-    if (iteration % 10 == 0 || iteration ==1){
-      cout <<"Iteration = "<<iteration<<", Sup Diff = "<<maxDifference<<"\n";
-    }
-  }
+	std::cout << "Iteration = " << iteration << ", Sup Diff = " << maxDifference << "\n";
+	endl(std::cout);
+	std::cout << "My check = " << mPolicyFunction[999][2] << "\n";
+	endl(std::cout);
 
-  cout <<"Iteration = "<<iteration<<", Sup Diff = "<<maxDifference<<"\n";
-  cout <<" \n";
-  cout <<"My check = "<< mPolicyFunction[999][2]<<"\n";
-  cout <<" \n";
-  
-  double cpu1  = get_cpu_time();
+	const auto time_1 = std::chrono::steady_clock::now();
+	const auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(time_1 - time_0).count();
+	std::cout << "Elapsed time is   = " << elapsed_seconds << " seconds." << std::endl;
+	endl(std::cout);
 
-  cout << "Elapsed time is   = " << cpu1  - cpu0  << endl;
-    
-  cout <<" \n";  
-
-  return 0;
-
+	return 0;
 }


### PR DESCRIPTION
- (bug fix) uninitialized variables (default-initialized locals, which results in indeterminate values), values of which are relied upon in the subsequent calculations, are now correctly initialized (value-initialized).
  
  Essentially, the fix amounts to the adherence to the rules EXP33-CPP (Do not reference uninitialized memory) and DCL19-CPP (Initialize automatic local variables on declaration) in the following:
  https://www.securecoding.cert.org/confluence/display/cplusplus/EXP33-CPP.+Do+not+reference+uninitialized+memory
  https://www.securecoding.cert.org/confluence/display/cplusplus/DCL19-CPP.+Initialize+automatic+local+variables+on+declaration
  
  See also: http://stackoverflow.com/questions/18295302/default-initialization-of-stdarray
- (code simplification, robustness) [related to the above bug fix] fix violations of DCL07-CPP (Minimize the scope of variables and methods)
  
  The scope was broader than necessary; this is more error-prone, as it increases the risk of uninitialized variables (it may also hinder understandability, since it requires a deep understanding of the potential variable interaction / reuse in a broader context than the one it's actually used in):
  https://www.securecoding.cert.org/confluence/display/cplusplus/DCL07-CPP.+Minimize+the+scope+of+variables+and+methods 
  // note: adherence to the rule DCL07-CPP helps with the rules EXP33-CPP and DCL19-CPP as a side benefit
- (code simplification, portability, standard-compliance): replace `get_cpu_time` (relying on platform-specific functionality) with the standard `<chrono>` library: http://en.cppreference.com/w/cpp/chrono
- (code simplification, readability): replace low-level C-style arrays with `Vector` and `Matrix` where appropriate
  
  Rationale: to aid with the conceptual understanding of the role the respective variables play in the model corresponding to the code. In order to remain compatible with the existing design relying on (compile-time) fixed-size C-style arrays, both `Vector` and `Matrix` are defined in terms of (also compile-time fixed-size) `std::array`.
- (code simplification, portability, standard-compliance): replace `int` with `std::size_t` where appropriate. 
  
  This improves the understandability, since it makes it clear that we have a concept corresponding to sample-size in statistics / econometrics -- it may be easier to understand and relate to, esp. for the audience coming from these fields. In particular, only non-negative values make sense in these contexts, which would not be (self-)documented nor ensured by `int`. This improves portability, since `int` is not guaranteed to be wide enough to be used for indexes/sizes. This also complies with what the standard core language & standard libraries do (both C and C++ expect and use `(std::)size_t` for sizes -- see `sizeof` operator, `operator[]` for containers like `std::array` and `std::vector`, etc.).
  
  See:
  http://stackoverflow.com/questions/7689288/less-verbose-way-to-declare-multidimensional-stdarray
  http://stackoverflow.com/questions/18295302/default-initialization-of-stdarray
  http://en.cppreference.com/w/cpp/types/size_t
  http://www.viva64.com/en/a/0050/
- (code simplification, robustness) replace magic number `-100000.0` with `-std::numeric_limits<double>::infinity();`
  
  Rationale: to clarify / express the intent of having a value that's always smaller than any other finite value on comparison.
- (code simplification, readability) improve const-correctness
  
  Rationale: to ease the reasoning regarding the variables intended to be modified -- and separate from the `const` values; see:
  http://en.wikipedia.org/wiki/Const-correctness
  https://isocpp.org/wiki/faq/const-correctness
  http://www.possibility.com/Cpp/const.html
- (code robustness) follow the recommended practice (Standard C++ Foundation) on the use of using-directive: http://isocpp.org/wiki/faq/coding-standards#using-namespace-std
