### PR TITLE
Mathematica code - speed and comparability

### DIFF
--- a/Mathematica_Plain_Text.txt
+++ b/Mathematica_Plain_Text.txt
@@ -1,127 +1,129 @@
-Clear["Global`*"];
+ClearAll["Global`*"]
 
 AbsoluteTiming[
- 
- (* Compiling the inner Loop *) 
- (* NOTE: Using the un-documented Compile`GetElement function instead \
-of Part *)
- 
- innerLoop = 
-  Compile[{{mOutput, _Real, 2}, {vGridCapital, _Real, 
-     1}, {nGridCapital, _Integer},
-    {nGridProductivity, _Integer}, {expectedValueFunction, _Real, 
-     2}},
-   With[{initialCapital = First[vGridCapital]},
-    Table[
-     Module[{gridCapitalNextPeriod = 1}, 
-      Table[
-       With[{output = 
-          Compile`GetElement[mOutput, nCapital, nProductivity]},
-        Module[{
-          valueProvisional = 0.,
-          valueHighSoFar = -1000.0, 
-          capitalChoice = initialCapital}, 
-         Catch@Do[
-           
-           valueProvisional = 
-            0.05 Log[
-               output - 
-                Compile`GetElement[vGridCapital, nCapitalNextPeriod]] +
-             
-             0.95 Compile`GetElement[expectedValueFunction, 
-               nCapitalNextPeriod, nProductivity];
-           If[valueProvisional > valueHighSoFar,
-            valueHighSoFar = valueProvisional;
-            
-            capitalChoice = 
-             Compile`GetElement[vGridCapital, nCapitalNextPeriod];
-            gridCapitalNextPeriod = nCapitalNextPeriod;
-            ,
-            Throw[{valueHighSoFar, capitalChoice}]
-            ],
-            {nCapitalNextPeriod, gridCapitalNextPeriod, 
-            nGridCapital}]]], 
-       {nCapital, nGridCapital}]],
-     {nProductivity, nGridProductivity}]
-    ],
-   CompilationTarget -> "C", "RuntimeOptions" -> "Speed" ];
- 
- 
- (* 1. Calibration*)
- \[Alpha] = 0.333333333333;
- \[Beta] = 0.95;
- 
- (* Productivity values*)
- 
- vProductivity = {0.9792, 0.9896, 1.0000, 1.0106, 1.0212};
- 
- (* Transition matrix *)
- 
- mTransition = {{0.9727, 0.0273, 0.0000, 0.0000, 0.0000},
-   {0.0041, 0.9806, 0.0153, 0.0000, 0.0000},
-   {0.0000, 0.0082, 0.9837, 0.0082, 0.0000},
-   {0.0000, 0.0000, 0.0153, 0.9806, 0.0041},
-   {0.0000, 0.0000, 0.0000, 0.0273, 0.9727}};
- mTransitionTransposed = Transpose[mTransition];
- 
- (* 2. Steady State*)
- 
- Subscript[k, ss] = (\[Alpha] \[Beta])^(1/(1 - \[Alpha]));
-   Subscript[y, ss] = Subscript[k, ss]^\[Alpha];
-   Subscript[c, ss] = Subscript[y, ss] - Subscript[k, ss];
- 
- (* We generate the grid of capital*)
- 
- vGridCapital = 
-  Range[0.5 Subscript[k, ss], 1.5 Subscript[k, ss], 0.00001];
- nGridCapital = Length[vGridCapital];
- nGridProductivity = Length[vProductivity];
- 
- (*3. Required matrices and vectors*)
- 
- mOutput = ConstantArray[0, {nGridCapital, nGridProductivity}];
-   mValueFunction = 
-  ConstantArray[0, {nGridCapital, nGridProductivity}];
-   mValueFunctionNew = 
-  ConstantArray[0, {nGridCapital, nGridProductivity}];
-   mPolicyFunction = 
-  ConstantArray[0, {nGridCapital, nGridProductivity}]; 
- expectedValueFunction = 
-  ConstantArray[0, {nGridCapital, nGridProductivity}];
- 
- (*4. We pre-build output for each point in the grid*)
-  
- mOutput = Transpose[{vGridCapital^\[Alpha]}].{vProductivity};
- 
- (* FixedPoint *)
- tolerance = 0.0000001;
-   iteration = 0;
- dis = 0;
- 
- (* outer Loop function *)
- 
- outerLoop[{mValueFunction_, mPolicyFunction_}] := Transpose[
-   innerLoop[mOutput, vGridCapital, nGridCapital, nGridProductivity,
-    Dot[mValueFunction, mTransitionTransposed]], 
-   {3, 2, 1}];
- 
- 
- (* Iteration *)
- {mValueFunction, mPolicyFunction} = 
-  FixedPoint[outerLoop, {mValueFunction, mPolicyFunction},
-   SameTest ->
-    (
-     (dis = Max[Abs[#1[[1]] - #2[[1]]]];  
-        iteration++;
-       If[Mod[iteration, 10] == 0 ||  iteration == 1,
-        Print[
-         StringForm["Iteration = ``, Sup Diff = ``", iteration, 
-          dis]]]; 
-       dis < tolerance ) &
-     )
-   ];
- 
- Print[StringForm["Iteration = ``, Sup Diff = ``", iteration, dis]];
- Print[StringForm["My check = ``", mPolicyFunction[[1000, 3]]]];
- 
- ]
+
+    Module[
+        {
+            alpha, beta, vProductivity, mTransition, mTransitionTransposed,
+            kss, yss, css, vGridCapital, nGridCapital, nGridProductivity, mOutput,
+            tolerance, mValueFunction, mPolicyFunction
+        },
+
+        (* 1. Calibration *)
+        alpha = 0.333333333333;
+        beta = 0.95;
+
+        (* Productivity values *)
+        vProductivity = {0.9792, 0.9896, 1.0000, 1.0106, 1.0212};
+
+        (* Transition matrix *)
+        mTransition = {
+            {0.9727, 0.0273, 0.0000, 0.0000, 0.0000},
+            {0.0041, 0.9806, 0.0153, 0.0000, 0.0000},
+            {0.0000, 0.0082, 0.9837, 0.0082, 0.0000},
+            {0.0000, 0.0000, 0.0153, 0.9806, 0.0041},
+            {0.0000, 0.0000, 0.0000, 0.0273, 0.9727}};
+        mTransitionTransposed = Transpose[mTransition];
+
+        (*2. Steady State *)
+        kss = (alpha beta)^(1 / (1 - alpha));
+        yss = kss^alpha;
+        css = yss - kss;
+
+        (* 4. We generate the grid of capital *)
+        vGridCapital = Range[0.5 kss, 1.5 kss, 0.00001];
+        nGridCapital = Length[vGridCapital];
+        nGridProductivity = Length[vProductivity];
+
+        (* 5. We pre-build output for each point in the grid *)
+        mOutput = Transpose[{vGridCapital^alpha}].{vProductivity};
+
+
+        (* 6. Compiling the Inner Loop *)
+        With[
+            {
+            (* Using undocumented function GetElement for faster access to Array elements *)
+                part = Compile`GetElement,
+                beta = beta
+            },
+            innerLoop = Compile[
+                {
+                    {mOutput, _Real, 2}, {vGridCapital, _Real, 1},  {nGridCapital, _Integer},
+                    {nGridProductivity, _Integer}, {expectedValueFunction, _Real, 2}
+                },
+                Module[
+                    {
+                    (* Initializations *)
+                        tmpOutput = Table[0., {2}, {nGridCapital}, {nGridProductivity}],
+                        valueProvisional
+                    },
+                    Do[
+                        Module[
+                            {
+                                gridCapitalNextPeriod = 1
+                            },
+                            Do[
+                                Module[
+                                    {
+                                        valueHighSoFar = -1000.,
+                                        capitalChoice = part[vGridCapital, -1],
+                                        y = part[mOutput, nCapital, nProductivity]
+                                    },
+                                    Do[
+                                        valueProvisional = (1 - beta) *
+                                            Log[Subtract[y, part[vGridCapital, nCapitalNextPeriod]]] +
+                                            beta part[expectedValueFunction, nCapitalNextPeriod, nProductivity];
+                                        If[valueHighSoFar < valueProvisional,
+                                            (
+                                                valueHighSoFar = valueProvisional;
+                                                capitalChoice = part[vGridCapital, nCapitalNextPeriod];
+                                                gridCapitalNextPeriod = nCapitalNextPeriod;
+                                            ),
+                                            Break[]
+                                        ],
+                                        {nCapitalNextPeriod, gridCapitalNextPeriod, nGridCapital}
+                                    ];
+                                    tmpOutput[[1, nCapital, nProductivity]] = valueHighSoFar;
+                                    tmpOutput[[2, nCapital, nProductivity]] = capitalChoice;
+                                ],
+                                {nCapital, nGridCapital}
+                            ]
+                        ],
+                        {nProductivity, nGridProductivity}
+                    ];
+                    tmpOutput
+                ],
+                CompilationTarget -> "C",
+                "RuntimeOptions" -> "Speed"
+            ]
+        ];
+
+        (* 7. Value Function Iteration *)
+        tolerance = 0.0000001;
+        {mValueFunction, mPolicyFunction} =
+            FixedPoint[
+                innerLoop[
+                    mOutput, vGridCapital, nGridCapital, nGridProductivity,
+                    Dot[#[[1]], mTransitionTransposed]
+                ] &,
+                Table[0., {2}, {nGridCapital}, {nGridProductivity}] (* Starting value *),
+                SameTest -> Module[
+                    {
+                        iteration = 1
+                    },
+                    Module[{dis = Max[Abs[Subtract[#1[[1]], #2[[1]]]]]},
+                        If[
+                            Mod[iteration, 10] == 0 || iteration == 1,
+                            Print["Iteration = ", iteration, " Sup Diff = ", dis]
+
+                        ];
+                        iteration++;
+                        dis < tolerance
+                    ] &
+                ]
+            ];
+
+        Print["My check = ", mPolicyFunction[[1000, 3]]];
+    ];
+
+]


### PR DESCRIPTION
- Changed the innerLoop so that it is closer to the implementations in
  other languages.
- Removed the Transpose call from the outerLoop, and made the outerLoop
  an anonymous function within the FixedPoint call.
- Made “beta” a parameter in the definition of the innerLoop (rather
  than a hardcoded number). As a result, moved the definition of the
  innerLoop until after the declaration of beta.
- Removed some unnecessary definitions.
- Removed Subscripts and […] notation, so that the code can be more
  easily read from plaintext.
- Code now runs faster.
