### PR TITLE
Re-factor Rcpp code

### DIFF
--- a/BothLoops.cpp
+++ b/BothLoops.cpp
@@ -3,8 +3,8 @@
 #include <cmath>
 
 // [[Rcpp::export]]
-Rcpp::NumericVector SingleLoop(Rcpp::NumericVector vProductivity, Rcpp::NumericVector vGridCapital,
-                               Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
+Rcpp::NumericVector BothLoops(Rcpp::NumericVector vProductivity, Rcpp::NumericVector vGridCapital,
+                              Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
   
   const double bbeta  = 0.95;
   

--- a/BothLoops.cpp
+++ b/BothLoops.cpp
@@ -3,22 +3,22 @@
 #include <cmath>
 
 // [[Rcpp::export]]
-Rcpp::NumericVector BothLoops(Rcpp::NumericVector vProductivity, Rcpp::NumericVector vGridCapital,
-                              Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
+Rcpp::NumericVector BothLoops(Rcpp::NumericVector& vProductivity, Rcpp::NumericVector& vGridCapital,
+                              Rcpp::NumericMatrix& mOutput, Rcpp::NumericMatrix& mTransition,
+                              Rcpp::NumericVector& bbeta_, Rcpp::IntegerVector& nGridCapital_, 
+                              Rcpp::IntegerVector& nGridProductivity_){
   
-  const double bbeta  = 0.95;
-  
-  const int nGridCapital = 17820, nGridProductivity = 5;
+  const int nGridCapital = nGridCapital_[0];
+  const int nGridProductivity = nGridProductivity_[0];
+  const double bbeta = bbeta_[0];
   
   double valueProvisional, valueHighSoFar, consumption, capitalChoice;
   
-  int nProductivity, nCapital, nCapitalNextPeriod, gridCapitalNextPeriod;
+  int nProductivity, nProductivityNextPeriod, nCapital, nCapitalNextPeriod, gridCapitalNextPeriod;
   
   double maxDifference = 10.0, diff, diffHighSoFar;
   double tolerance = 0.0000001;
-  double iteration = 0;
-  
-  int nProductivityNextPeriod;
+  int iteration = 0;
   
   Rcpp::NumericMatrix mValueFunctionNew(nGridCapital,nGridProductivity);
   Rcpp::NumericMatrix mValueFunction(nGridCapital,nGridProductivity);
@@ -79,7 +79,7 @@ Rcpp::NumericVector BothLoops(Rcpp::NumericVector vProductivity, Rcpp::NumericVe
     maxDifference = diffHighSoFar;
     
     iteration = iteration+1;
-    if (floor(iteration/10)==iteration/10 || iteration ==1){
+    if (iteration % 10 ==0 || iteration ==1){
       Rcpp::Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<< maxDifference<<"\n";
     }
   }

--- a/RBC_Rcpp_2.R
+++ b/RBC_Rcpp_2.R
@@ -1,0 +1,54 @@
+## 0. Housekeeping
+
+rm(list=ls())
+
+Rcpp::sourceCpp('SingleLoop.cpp');
+
+ptm <- proc.time()
+
+##  1. Calibration
+
+aalpha = 1/3;     # Elasticity of output w.r.t. capital
+bbeta  = 0.95;    # Discount factor
+
+# Productivity values
+vProductivity <- c(0.9792, 0.9896, 1.0000, 1.0106, 1.0212);
+
+# Transition matrix
+mTransition <- c(0.9727, 0.0273, 0.0000, 0.0000, 0.0000,
+                 0.0041, 0.9806, 0.0153, 0.0000, 0.0000,
+                 0.0000, 0.0082, 0.9837, 0.0082, 0.0000,
+                 0.0000, 0.0000, 0.0153, 0.9806, 0.0041,
+                 0.0000, 0.0000, 0.0000, 0.0273, 0.9727);
+
+mTransition <- matrix(mTransition,nrow=5,ncol=5);
+mTransition <- t(mTransition)
+
+## 2. Steady State
+
+capitalSteadyState = (aalpha*bbeta)^(1/(1-aalpha));
+outputSteadyState = capitalSteadyState^aalpha;
+consumptionSteadyState = outputSteadyState-capitalSteadyState;
+
+cat(" Output = ", outputSteadyState,", Capital = ",capitalSteadyState, ", Consumption = ", consumptionSteadyState,"\n") 
+cat(" \n")
+
+# We generate the grid of capital
+vGridCapital <- seq(0.5*capitalSteadyState, 1.5*capitalSteadyState, by = 0.00001);
+
+nGridCapital <- length(vGridCapital);
+nGridProductivity <- length(vProductivity);
+
+# 3. Required matrices and vectors
+
+mOutput <- matrix(0,nGridCapital,nGridProductivity);
+
+## 4. We pre-build output for each point in the grid
+
+mOutput = vGridCapital^aalpha%*%t(vProductivity);
+
+## 5. Main iteration
+
+mPolicyFunction <- SingleLoop(vProductivity,vGridCapital, mOutput, mTransition);
+
+cat(" Time = ", proc.time() - ptm,"\n"); 

--- a/RBC_Rcpp_2.R
+++ b/RBC_Rcpp_2.R
@@ -2,53 +2,53 @@
 
 rm(list=ls())
 
-Rcpp::sourceCpp('SingleLoop.cpp');
+Rcpp::sourceCpp('SingleLoop.cpp')
 
 ptm <- proc.time()
 
 ##  1. Calibration
 
-aalpha = 1/3;     # Elasticity of output w.r.t. capital
-bbeta  = 0.95;    # Discount factor
+aalpha <- 1/3     # Elasticity of output w.r.t. capital
+bbeta  <- 0.95    # Discount factor
 
 # Productivity values
-vProductivity <- c(0.9792, 0.9896, 1.0000, 1.0106, 1.0212);
+vProductivity <- c(0.9792, 0.9896, 1.0000, 1.0106, 1.0212)
 
 # Transition matrix
 mTransition <- c(0.9727, 0.0273, 0.0000, 0.0000, 0.0000,
                  0.0041, 0.9806, 0.0153, 0.0000, 0.0000,
                  0.0000, 0.0082, 0.9837, 0.0082, 0.0000,
                  0.0000, 0.0000, 0.0153, 0.9806, 0.0041,
-                 0.0000, 0.0000, 0.0000, 0.0273, 0.9727);
+                 0.0000, 0.0000, 0.0000, 0.0273, 0.9727)
 
-mTransition <- matrix(mTransition,nrow=5,ncol=5);
+mTransition <- matrix(mTransition,nrow=5,ncol=5)
 mTransition <- t(mTransition)
 
 ## 2. Steady State
 
-capitalSteadyState = (aalpha*bbeta)^(1/(1-aalpha));
-outputSteadyState = capitalSteadyState^aalpha;
-consumptionSteadyState = outputSteadyState-capitalSteadyState;
+capitalSteadyState <- (aalpha*bbeta)^(1/(1-aalpha))
+outputSteadyState <- capitalSteadyState^aalpha
+consumptionSteadyState <- outputSteadyState-capitalSteadyState
 
 cat(" Output = ", outputSteadyState,", Capital = ",capitalSteadyState, ", Consumption = ", consumptionSteadyState,"\n") 
 cat(" \n")
 
 # We generate the grid of capital
-vGridCapital <- seq(0.5*capitalSteadyState, 1.5*capitalSteadyState, by = 0.00001);
+vGridCapital <- seq(0.5*capitalSteadyState, 1.5*capitalSteadyState, by = 0.00001)
 
-nGridCapital <- length(vGridCapital);
-nGridProductivity <- length(vProductivity);
+nGridCapital <- length(vGridCapital)
+nGridProductivity <- length(vProductivity)
 
 # 3. Required matrices and vectors
 
-mOutput <- matrix(0,nGridCapital,nGridProductivity);
+mOutput <- matrix(0,nGridCapital,nGridProductivity)
 
 ## 4. We pre-build output for each point in the grid
 
-mOutput = vGridCapital^aalpha%*%t(vProductivity);
+mOutput = vGridCapital^aalpha%*%t(vProductivity)
 
 ## 5. Main iteration
 
-mPolicyFunction <- SingleLoop(vProductivity,vGridCapital, mOutput, mTransition);
+mPolicyFunction <- SingleLoop(vProductivity,vGridCapital, mOutput, mTransition)
 
-cat(" Time = ", proc.time() - ptm,"\n"); 
+cat(" Time = ", proc.time() - ptm,"\n") 

--- a/RBC_Rcpp_2.R
+++ b/RBC_Rcpp_2.R
@@ -49,6 +49,9 @@ mOutput = vGridCapital^aalpha%*%t(vProductivity)
 
 ## 5. Main iteration
 
-mPolicyFunction <- BothLoops(vProductivity,vGridCapital, mOutput, mTransition)
+mPolicyFunction <- BothLoops(
+  vProductivity,vGridCapital, mOutput, mTransition, bbeta, nGridCapital, 
+  nGridProductivity
+)
 
 cat(" Time = ", proc.time() - ptm,"\n") 

--- a/RBC_Rcpp_2.R
+++ b/RBC_Rcpp_2.R
@@ -2,7 +2,7 @@
 
 rm(list=ls())
 
-Rcpp::sourceCpp('SingleLoop.cpp')
+Rcpp::sourceCpp('BothLoops.cpp')
 
 ptm <- proc.time()
 
@@ -49,6 +49,6 @@ mOutput = vGridCapital^aalpha%*%t(vProductivity)
 
 ## 5. Main iteration
 
-mPolicyFunction <- SingleLoop(vProductivity,vGridCapital, mOutput, mTransition)
+mPolicyFunction <- BothLoops(vProductivity,vGridCapital, mOutput, mTransition)
 
 cat(" Time = ", proc.time() - ptm,"\n") 

--- a/SingleLoop.cpp
+++ b/SingleLoop.cpp
@@ -59,7 +59,6 @@ Rcpp::NumericVector SingleLoop(Rcpp::NumericVector vProductivity, Rcpp::NumericV
           else{
             break; // We break when we have achieved the max
           }
-          
           mValueFunctionNew(nCapital,nProductivity) = valueHighSoFar;
           mPolicyFunction(nCapital,nProductivity) = capitalChoice;
         }
@@ -83,13 +82,12 @@ Rcpp::NumericVector SingleLoop(Rcpp::NumericVector vProductivity, Rcpp::NumericV
     if (floor(iteration/10)==iteration/10 || iteration ==1){
       Rcpp::Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<< maxDifference<<"\n";
     }
-    
   }
+  
   Rcpp::Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<<maxDifference<<"\n";
   Rcpp::Rcout <<" \n";
   Rcpp::Rcout <<"My check = "<< mPolicyFunction(999,2)<<"\n";
   Rcpp::Rcout <<" \n";
   
   return mPolicyFunction;
-  
 }

--- a/SingleLoop.cpp
+++ b/SingleLoop.cpp
@@ -4,7 +4,7 @@
 
 // [[Rcpp::export]]
 Rcpp::NumericVector SingleLoop(Rcpp::NumericVector vProductivity, Rcpp::NumericVector vGridCapital,
-                         Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
+                               Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
   
   const double bbeta  = 0.95;
   

--- a/SingleLoop.cpp
+++ b/SingleLoop.cpp
@@ -1,0 +1,97 @@
+#include <Rcpp.h>
+#include <math.h>       // power
+#include <cmath>
+using namespace Rcpp;
+
+
+// [[Rcpp::export]]
+NumericVector SingleLoop(NumericVector vProductivity, NumericVector vGridCapital,
+                         NumericMatrix mOutput, NumericMatrix mTransition){
+  
+  const double bbeta  = 0.95;
+  
+  const int nGridCapital = 17820, nGridProductivity = 5;
+  
+  double valueProvisional, valueHighSoFar, consumption, capitalChoice;
+  
+  int nProductivity, nCapital, nCapitalNextPeriod, gridCapitalNextPeriod;
+  
+  double maxDifference = 10.0, diff, diffHighSoFar;
+  double tolerance = 0.0000001;
+  double iteration = 0;
+  
+  int nProductivityNextPeriod;
+  
+  NumericMatrix mValueFunctionNew(nGridCapital,nGridProductivity);
+  NumericMatrix mValueFunction(nGridCapital,nGridProductivity);
+  NumericMatrix mPolicyFunction(nGridCapital,nGridProductivity);
+  NumericMatrix expectedValueFunction(nGridCapital,nGridProductivity);
+  
+  while(maxDifference > tolerance) {
+    
+    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
+      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
+        expectedValueFunction(nCapital,nProductivity) = 0.0;
+        for (nProductivityNextPeriod = 0;nProductivityNextPeriod<nGridProductivity;++nProductivityNextPeriod){
+          expectedValueFunction(nCapital,nProductivity) += mTransition(nProductivity,nProductivityNextPeriod)*mValueFunction(nCapital,nProductivityNextPeriod);
+        }
+      }
+    }
+  
+    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
+      
+      // We start from previous choice (monotonicity of policy function)
+      gridCapitalNextPeriod = 0;
+      
+      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
+        
+        valueHighSoFar = -100000.0;
+        capitalChoice  = vGridCapital[0];
+        
+        for (nCapitalNextPeriod = gridCapitalNextPeriod;nCapitalNextPeriod<nGridCapital;++nCapitalNextPeriod){
+          
+          consumption = mOutput(nCapital,nProductivity)-vGridCapital[nCapitalNextPeriod];
+          valueProvisional = (1-bbeta)*log(consumption)+bbeta*expectedValueFunction(nCapitalNextPeriod,nProductivity);
+          
+          if (valueProvisional>valueHighSoFar){
+            valueHighSoFar = valueProvisional;
+            capitalChoice = vGridCapital[nCapitalNextPeriod];
+            gridCapitalNextPeriod = nCapitalNextPeriod;
+          }
+          else{
+            break; // We break when we have achieved the max
+          }
+          
+          mValueFunctionNew(nCapital,nProductivity) = valueHighSoFar;
+          mPolicyFunction(nCapital,nProductivity) = capitalChoice;
+        }
+      }
+    }
+    
+    diffHighSoFar = -100000.0;
+    for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
+      for (nCapital = 0;nCapital<nGridCapital;++nCapital){
+        diff = std::abs(mValueFunction(nCapital,nProductivity)-mValueFunctionNew(nCapital,nProductivity));
+        if (diff>diffHighSoFar){
+          diffHighSoFar = diff;
+        }
+        mValueFunction(nCapital,nProductivity) = mValueFunctionNew(nCapital,nProductivity);
+      }
+    }
+    
+    maxDifference = diffHighSoFar;
+    
+    iteration = iteration+1;
+    if (floor(iteration/10)==iteration/10 || iteration ==1){
+      Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<< maxDifference<<"\n";
+    }
+    
+  }
+  Rcpp::Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<<maxDifference<<"\n";
+  Rcpp::Rcout <<" \n";
+  Rcpp::Rcout <<"My check = "<< mPolicyFunction(999,2)<<"\n";
+  Rcpp::Rcout <<" \n";
+  
+  return mPolicyFunction;
+  
+}

--- a/SingleLoop.cpp
+++ b/SingleLoop.cpp
@@ -1,12 +1,10 @@
 #include <Rcpp.h>
 #include <math.h>       // power
 #include <cmath>
-using namespace Rcpp;
-
 
 // [[Rcpp::export]]
-NumericVector SingleLoop(NumericVector vProductivity, NumericVector vGridCapital,
-                         NumericMatrix mOutput, NumericMatrix mTransition){
+Rcpp::NumericVector SingleLoop(Rcpp::NumericVector vProductivity, Rcpp::NumericVector vGridCapital,
+                         Rcpp::NumericMatrix mOutput, Rcpp::NumericMatrix mTransition){
   
   const double bbeta  = 0.95;
   
@@ -22,10 +20,10 @@ NumericVector SingleLoop(NumericVector vProductivity, NumericVector vGridCapital
   
   int nProductivityNextPeriod;
   
-  NumericMatrix mValueFunctionNew(nGridCapital,nGridProductivity);
-  NumericMatrix mValueFunction(nGridCapital,nGridProductivity);
-  NumericMatrix mPolicyFunction(nGridCapital,nGridProductivity);
-  NumericMatrix expectedValueFunction(nGridCapital,nGridProductivity);
+  Rcpp::NumericMatrix mValueFunctionNew(nGridCapital,nGridProductivity);
+  Rcpp::NumericMatrix mValueFunction(nGridCapital,nGridProductivity);
+  Rcpp::NumericMatrix mPolicyFunction(nGridCapital,nGridProductivity);
+  Rcpp::NumericMatrix expectedValueFunction(nGridCapital,nGridProductivity);
   
   while(maxDifference > tolerance) {
     
@@ -37,7 +35,7 @@ NumericVector SingleLoop(NumericVector vProductivity, NumericVector vGridCapital
         }
       }
     }
-  
+    
     for (nProductivity = 0;nProductivity<nGridProductivity;++nProductivity){
       
       // We start from previous choice (monotonicity of policy function)
@@ -83,7 +81,7 @@ NumericVector SingleLoop(NumericVector vProductivity, NumericVector vGridCapital
     
     iteration = iteration+1;
     if (floor(iteration/10)==iteration/10 || iteration ==1){
-      Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<< maxDifference<<"\n";
+      Rcpp::Rcout <<"Iteration = "<<iteration<<", Sup Diff = "<< maxDifference<<"\n";
     }
     
   }


### PR DESCRIPTION
1. Moves the `sourceCpp` call outside of the outer loop (it should be called only once), and prior to the start of the timer (so that the timing results don't include compilation time)
1.  The compiled code is re-factored so that there is just a single call to the Rcpp stuff to do the calculations (prevents repeated switching back and forth between R and Rcpp)
1. I maintained the original flow of the code as much as possible and retained the original Rcpp files for comparison

Thanks for considering the pull request.

Kyle



